### PR TITLE
fix levelAsGraph's bug

### DIFF
--- a/src/game/enemyai/AIGameState.scala
+++ b/src/game/enemyai/AIGameState.scala
@@ -26,10 +26,13 @@ class AIGameState {
     }
 
     for ((id, location) <- graph.nodes) {
-      val potentialConnections = List(
-        new GridLocation(location.x + 1, location.y),
-        new GridLocation(location.x, location.y + 1)
-      )
+      var potentialConnections = List[GridLocation]()
+      if (location.x + 1 < levelWidth) {
+        potentialConnections = (new GridLocation(location.x + 1, location.y)) :: potentialConnections
+      }
+      if (location.y + 1 < levelHeight) {
+        potentialConnections = (new GridLocation(location.x, location.y + 1)) :: potentialConnections
+      }
 
       for (loc <- potentialConnections) {
         if (graph.nodes.contains(gridID(loc)) && loc.x < this.levelWidth && loc.y < this.levelHeight){


### PR DESCRIPTION
In the original code, the `levelAsGraph` didn't test if the next grid is in the legal `levelHeight` and `levelWidth` range, and this would potentially cause issues, especially with the gridID is generating the unique girdID by grid x and y location.

For instance, if I have a game level in which the width and height are 3, which means the legal range for the map is (x: 0-2), (y: 0-2).
In this case, when it generates edge for block `(2, 1)|(id: 5)`, if we don't test the legal range for it, it will try to connect it to `(3,1)|(id:3)` and `(2,2)|(id:8)`. Meanwhile, the grid `(0,2)` also has the gridID of `6`. So in this case, the program will think the grid `(2,1)` is connected to the grid `(0,2)`.

And I jogged down a simple graph for it
![20210501165005](https://user-images.githubusercontent.com/20598278/116794736-57873c00-aa9d-11eb-9dbb-9a7e0d1c1689.jpg)


__

Test Code:
```
val gameState = new AIGameState()
gameState.levelWidth = 3
gameState.levelHeight = 3
gameState.wallLocations = List(
  new GridLocation(0, 1),
  new GridLocation(1, 1)
)

val graph = gameState.levelAsGraph()
println(graph.adjacencyList(5))
``` 

And the result with the original code is `List(2, 8, 6)`, which apparently is not correct, according to the graph above, grid 6 is (0,2).

If we add a legal range test, this issue will be fixed, and the result for the test code is `List(2,8)`
